### PR TITLE
Use latest TFHEpp

### DIFF
--- a/src/backstream_dfa_runner.hpp
+++ b/src/backstream_dfa_runner.hpp
@@ -11,7 +11,7 @@ class BackstreamDFARunner {
 private:
     Graph graph_;
     std::vector<TRLWELvl1> weight_;
-    std::shared_ptr<GateKey> gate_key_;
+    std::shared_ptr<EvalKey> eval_key_;
     std::optional<size_t> input_size_;
     const size_t boot_interval_;
     size_t num_processed_inputs_;
@@ -26,7 +26,7 @@ private:
 public:
     BackstreamDFARunner(Graph graph, size_t boot_interval,
                         std::optional<size_t> input_size,
-                        std::shared_ptr<GateKey> gate_key,
+                        std::shared_ptr<EvalKey> eval_key,
                         bool sanitize_result);
 
     const Graph& graph() const

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -72,7 +72,7 @@ public:
                        size_t boot_interval, const BKey& bkey,
                        bool sanitize_result)
         : runner_(Graph::from_file(spec_filename), input_size, boot_interval,
-                  bkey.gkey, sanitize_result),
+                  bkey.ekey, sanitize_result),
           result_(),
           remaining_input_size_(input_size)
     {
@@ -109,7 +109,7 @@ public:
                           size_t bootstrapping_freq, bool spec_reversed,
                           const BKey& bkey, bool sanitize_result)
         : runner_(Graph::from_file(spec_filename), bootstrapping_freq,
-                  spec_reversed, bkey.gkey, sanitize_result),
+                  spec_reversed, bkey.ekey, sanitize_result),
           output_freq_(output_freq),
           num_processed_(0)
     {
@@ -153,7 +153,7 @@ public:
                           size_t bootstrapping_freq, const BKey& bkey,
                           bool sanitize_result)
         : runner_(Graph::from_file(spec_filename), max_second_lut_depth,
-                  queue_size, bootstrapping_freq, *bkey.gkey,
+                  queue_size, bootstrapping_freq, *bkey.ekey,
                   *bkey.tlwel1_trlwel1_ikskey, std::nullopt, sanitize_result),
           output_freq_(output_freq),
           queue_size_(queue_size),
@@ -196,8 +196,8 @@ public:
     OnlineDFA4BenchRunner(const std::string& spec_filename, size_t output_freq,
                           size_t queue_size, const BKey& bkey,
                           bool sanitize_result)
-        : runner_(Graph::from_file(spec_filename), queue_size, *bkey.gkey,
-                  *bkey.circuit_key, sanitize_result),
+        : runner_(Graph::from_file(spec_filename), queue_size, *bkey.ekey,
+                  sanitize_result),
           output_freq_(output_freq),
           queue_size_(queue_size),
           num_processed_(0)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -260,7 +260,7 @@ void do_run_offline(const std::string& spec_filename,
 
     auto bkey = read_from_archive<BKey>(bkey_filename);
     OfflineDFARunner runner{Graph::from_file(spec_filename).minimized(),
-                            input_stream.size(), bootstrapping_freq, bkey.gkey,
+                            input_stream.size(), bootstrapping_freq, bkey.ekey,
                             sanitize_result};
 
     spdlog::info("Parameter:");
@@ -325,7 +325,7 @@ void do_run_reverse(const std::string& spec_filename,
     TRGSWLvl1InputStreamFromCtxtFile input_stream{input_filename};
     auto bkey = read_from_archive<BKey>(bkey_filename);
     OnlineDFARunner2 runner{Graph::from_file(spec_filename), bootstrapping_freq,
-                            is_spec_reversed, bkey.gkey, sanitize_result};
+                            is_spec_reversed, bkey.ekey, sanitize_result};
 
     spdlog::info("Parameter:");
     spdlog::info("\tMode:\t{}", "Online FA Runner2 (reversed)");
@@ -379,7 +379,7 @@ void do_run_flut(const std::string& spec_filename,
     Graph gr = Graph::from_file(spec_filename);
 
     auto bkey = read_from_archive<BKey>(bkey_filename);
-    assert(bkey.gkey && bkey.tlwel1_trlwel1_ikskey);
+    assert(bkey.ekey && bkey.tlwel1_trlwel1_ikskey);
 
     std::optional<SecretKey> debug_skey;
     if (debug_skey_filename)
@@ -387,7 +387,7 @@ void do_run_flut(const std::string& spec_filename,
 
     OnlineDFARunner3 runner{gr,         max_second_lut_depth.value_or(8),
                             queue_size, bootstrapping_freq,
-                            *bkey.gkey, *bkey.tlwel1_trlwel1_ikskey,
+                            *bkey.ekey, *bkey.tlwel1_trlwel1_ikskey,
                             debug_skey, sanitize_result};
 
     spdlog::info("Parameter:");
@@ -442,10 +442,9 @@ void do_run_block(const std::string& spec_filename,
     Graph gr = Graph::from_file(spec_filename);
 
     auto bkey = read_from_archive<BKey>(bkey_filename);
-    assert(bkey.gkey);
+    assert(bkey.ekey);
 
-    OnlineDFARunner4 runner{gr, queue_size, *bkey.gkey, *bkey.circuit_key,
-                            sanitize_result};
+    OnlineDFARunner4 runner{gr, queue_size, *bkey.ekey, sanitize_result};
 
     spdlog::info("Parameter:");
     spdlog::info("\tMode:\t{}", "Online FA Runner4 (block-backstream)");

--- a/src/offline_dfa.cpp
+++ b/src/offline_dfa.cpp
@@ -6,9 +6,9 @@
 
 OfflineDFARunner::OfflineDFARunner(Graph graph, size_t input_size,
                                    size_t boot_interval,
-                                   std::shared_ptr<GateKey> gate_key,
+                                   std::shared_ptr<EvalKey> eval_key,
                                    bool sanitize_result)
-    : runner_(std::move(graph), boot_interval, input_size, gate_key,
+    : runner_(std::move(graph), boot_interval, input_size, eval_key,
               sanitize_result)
 {
 }

--- a/src/offline_dfa.hpp
+++ b/src/offline_dfa.hpp
@@ -9,7 +9,7 @@ private:
 
 public:
     OfflineDFARunner(Graph graph, size_t input_size, size_t boot_interval,
-                     std::shared_ptr<GateKey> gate_key, bool sanitize_result);
+                     std::shared_ptr<EvalKey> eval_key, bool sanitize_result);
 
     const Graph& graph() const
     {

--- a/src/online_dfa.hpp
+++ b/src/online_dfa.hpp
@@ -10,12 +10,12 @@ class OnlineDFARunner {
 private:
     Graph graph_;
     std::vector<TRLWELvl1> weight_;
-    std::shared_ptr<GateKey> gate_key_;
+    std::shared_ptr<EvalKey> eval_key_;
     size_t bootstrap_interval_, num_processed_inputs_;
     bool sanitize_result_;
 
 public:
-    OnlineDFARunner(const Graph& graph, std::shared_ptr<GateKey> gate_key,
+    OnlineDFARunner(const Graph& graph, std::shared_ptr<EvalKey> eval_key,
                     bool sanitize_result);
 
     TLWELvl1 result();
@@ -31,7 +31,7 @@ private:
 
 public:
     OnlineDFARunner2(const Graph& graph, size_t boot_interval_,
-                     bool is_spec_reversed, std::shared_ptr<GateKey> gate_key,
+                     bool is_spec_reversed, std::shared_ptr<EvalKey> eval_key,
                      bool sanitize_result);
 
     const Graph& graph() const
@@ -51,7 +51,7 @@ public:
 class OnlineDFARunner3 {
 private:
     Graph graph_;
-    const GateKey& gate_key_;
+    const EvalKey& eval_key_;
     const TFHEpp::TLWE2TRLWEIKSKey<TFHEpp::lvl11param>& tlwel1_trlwel1_iks_key_;
     std::vector<TRLWELvl1> weight_;
     std::vector<TRGSWLvl1FFT> queued_inputs_;
@@ -68,7 +68,7 @@ private:
 public:
     OnlineDFARunner3(Graph graph, size_t max_second_lut_depth,
                      size_t queue_size, size_t bootstrapping_freq,
-                     const GateKey& gate_key,
+                     const EvalKey& eval_key,
                      const TFHEpp::TLWE2TRLWEIKSKey<TFHEpp::lvl11param>&
                          tlwel1_trlwel1_iks_key,
                      std::optional<SecretKey> debug_skey, bool sanitize_result);
@@ -108,8 +108,7 @@ private:
 class OnlineDFARunner4 {
 private:
     Graph graph_;
-    const GateKey& gate_key_;
-    const CircuitKey& circuit_key_;
+    const EvalKey& eval_key_;
     size_t queue_size_;
     std::vector<TRGSWLvl1FFT> queued_inputs_;
     std::optional<TRLWELvl1> selector_;
@@ -118,13 +117,13 @@ private:
 
     std::vector<TRLWELvl1> workspace1_, workspace2_;
     std::vector<TRGSWLvl1FFT> workspace3_;
-    std::vector<TLWELvl0> workspace4_;
+    std::vector<TLWELvl1> workspace4_;
 
     TimeRecorder timer_;
 
 public:
-    OnlineDFARunner4(Graph graph, size_t queue_size, const GateKey& gate_key,
-                     const CircuitKey& circuit_key, bool sanitize_result);
+    OnlineDFARunner4(Graph graph, size_t queue_size, const EvalKey& eval_key,
+                     bool sanitize_result);
 
     const Graph& graph() const
     {


### PR DESCRIPTION
This patch updates TFHEpp to the latest version. The largest update in TFHEpp is the replacement of GateKey and CircuitKey with EvalKey.

I tested it by running `test_benchmark.sh` and `test_homfa.sh`